### PR TITLE
Implement support for base address

### DIFF
--- a/NativeLifters-Core/core/recursive_descent.hpp
+++ b/NativeLifters-Core/core/recursive_descent.hpp
@@ -36,17 +36,19 @@ namespace vtil::lifter
 {
 	struct byte_input
 	{
-		uint8_t* bytes;
-		uint64_t size;
+		uint8_t* bytes = nullptr;
+		uint64_t size = 0;
+		uint64_t base = 0;
 
 		bool is_valid( vip_t vip ) const
 		{
-			return vip < size;
+			return vip >= base && (vip - base) < size;
 		}
 
-		uint8_t* get_at( vip_t offs ) const
+		uint8_t* get_at( vip_t vip ) const
 		{
-			return &bytes[ offs ];
+			dassert( is_valid( vip ) );
+			return &bytes[ vip - base ];
 		}
 	};
 

--- a/NativeLifters-Tests/fuzzer.hpp
+++ b/NativeLifters-Tests/fuzzer.hpp
@@ -81,7 +81,7 @@ static bool fuzz_step( const lifter::byte_input& input, bool optimize, bool dump
 
 	// Lift all bytes
 	//
-	amd64_recursive_descent rec_desc( &input, 0 );
+	amd64_recursive_descent rec_desc( &input, input.base );
 	rec_desc.entry->owner->routine_convention = amd64::preserve_all_convention;
 	rec_desc.entry->owner->routine_convention.purge_stack = false;
 	rec_desc.explore();


### PR DESCRIPTION
The `vtil::lifter::byte_input` struct now has a `base` address, which is used by the `recursive_descent` as a base address for the lifted blocks.

Includes unit tests:

```
TEST_ADDR(0x140001000, R"(
push rax
pop rbx
)");
```