### PR TITLE
Fix translating lea with RIP relative register

### DIFF
--- a/NativeLifters-Core/amd64/amd64.cpp
+++ b/NativeLifters-Core/amd64/amd64.cpp
@@ -155,7 +155,7 @@ namespace vtil::lifter::amd64
 
 			if ( operand.type == X86_OP_MEM )
 			{
-				if ( operand.mem.base != X86_REG_INVALID && !vtil::amd64::is_generic( operand.mem.base ) )
+				if ( operand.mem.base != X86_REG_INVALID && operand.mem.base != X86_REG_RIP && !vtil::amd64::is_generic( operand.mem.base ) )
 				{
 					is_invalid = true;
 					break;

--- a/NativeLifters-Core/amd64/semantic/misc.cpp
+++ b/NativeLifters-Core/amd64/semantic/misc.cpp
@@ -131,7 +131,9 @@ namespace vtil::lifter::amd64
 			X86_INS_LEA,
 			[ ] ( basic_block* block, const instruction_info& insn )
 			{
-				store_operand( block, insn, 0, get_disp_from_operand( block, insn.operands[ 1 ] ) );
+				auto tmp = block->tmp(insn.operands[1].size * 8);
+				block->mov(tmp, get_disp_from_operand(block, insn.operands[1]));
+				store_operand(block, insn, 0, tmp);
 			}
 		},
 		{


### PR DESCRIPTION
This allows the lifting of instructions like 
```
0x703E42C    4C:8D15 3D2D2DFB    lea r10,qword ptr ds:[0x2311199]
```
```
 | | 0000: [ PSEUDO ]     +0x0     movq     rip          0x703e433
 | | 0001: [ PSEUDO ]     +0x0     movq     t1           0x0
 | | 0002: [ PSEUDO ]     +0x0     addq     t1           rip
 | | 0003: [ PSEUDO ]     +0x0     addq     t1           -0x4d2d2c3
 | | 0004: [ PSEUDO ]     +0x0     movq     t0           t1
 | | 0005: [ PSEUDO ]     +0x0     movq     r10          t0
 | | 0006: [ PSEUDO ]     +0x0     vexitq   -0x1
```