### PR TITLE
Implement SHLD and SHRD, handle SAL

### DIFF
--- a/NativeLifters-Core/amd64/semantic/arithmetic.cpp
+++ b/NativeLifters-Core/amd64/semantic/arithmetic.cpp
@@ -629,11 +629,11 @@ namespace vtil::lifter::amd64
 					auto lbso_pos = operative(o1.bit_count()) - count;
 
 					block
-						->bxor( flags::CF, ( o3 != 0 ) & ( operative( flags::CF ) ^ ( (operative( o1 ) >> lbso_pos) & 1 ) ) )
-						->bxor( flags::OF, ( o3 != 0 ) & ( operative( flags::OF ) ^ ( flags::sign( { result } ) ^ lhs_sign ) ) )
-						->bxor( flags::SF, ( o3 != 0 ) & ( operative( flags::SF ) ^ flags::sign( result ) ) )
-						->bxor( flags::ZF, ( o3 != 0 ) & ( operative( flags::ZF ) ^ flags::zero( result ) ) )
-						->bxor( flags::PF, ( o3 != 0 ) & ( operative( flags::PF ) ^ flags::parity( result ) ) );
+						->bxor( flags::CF, ( count != 0 ) & ( operative( flags::CF ) ^ ( (operative( o1 ) >> lbso_pos) & 1 ) ) )
+						->bxor( flags::OF, ( count != 0 ) & ( operative( flags::OF ) ^ ( flags::sign( { result } ) ^ lhs_sign ) ) )
+						->bxor( flags::SF, ( count != 0 ) & ( operative( flags::SF ) ^ flags::sign( result ) ) )
+						->bxor( flags::ZF, ( count != 0 ) & ( operative( flags::ZF ) ^ flags::zero( result ) ) )
+						->bxor( flags::PF, ( count != 0 ) & ( operative( flags::PF ) ^ flags::parity( result ) ) );
 
 					store_operand( block, insn, 0, result );
 				}
@@ -653,11 +653,11 @@ namespace vtil::lifter::amd64
 					auto lbso_pos = count - operative(1);
 
 					block
-						->bxor( flags::CF, ( o3 != 0 ) & ( operative( flags::CF ) ^ ( (operative( o1 ) >> lbso_pos) & 1 ) ) )
-						->bxor( flags::OF, ( o3 != 0 ) & ( operative( flags::OF ) ^ flags::sign( { o1 } ) ) )
-						->bxor( flags::SF, ( o3 != 0 ) & ( operative( flags::SF ) ^ flags::sign( result ) ) )
-						->bxor( flags::ZF, ( o3 != 0 ) & ( operative( flags::ZF ) ^ flags::zero( result ) ) )
-						->bxor( flags::PF, ( o3 != 0 ) & ( operative( flags::PF ) ^ flags::parity( result ) ) );
+						->bxor( flags::CF, ( count != 0 ) & ( operative( flags::CF ) ^ ( (operative( o1 ) >> lbso_pos) & 1 ) ) )
+						->bxor( flags::OF, ( count != 0 ) & ( operative( flags::OF ) ^ flags::sign( { o1 } ) ) )
+						->bxor( flags::SF, ( count != 0 ) & ( operative( flags::SF ) ^ flags::sign( result ) ) )
+						->bxor( flags::ZF, ( count != 0 ) & ( operative( flags::ZF ) ^ flags::zero( result ) ) )
+						->bxor( flags::PF, ( count != 0 ) & ( operative( flags::PF ) ^ flags::parity( result ) ) );
 
 					store_operand( block, insn, 0, result );
 				}

--- a/NativeLifters-Tests/main.cpp
+++ b/NativeLifters-Tests/main.cpp
@@ -137,6 +137,57 @@ pop rbx)");
 		leave
 )");*/
 
+	TEST("shld ax, bx, 0");
+	TEST("shld ax, bx, 1");
+	TEST("shld ax, bx, 15");
+	TEST(R"(
+		and cl, 15
+		shld ax, bx, cl
+		)");
+	TEST("shld eax, ebx, 0");
+	TEST("shld eax, ebx, 1");
+	TEST("shld eax, ebx, 31");
+	TEST(R"(
+		and cl, 31
+		shld eax, ebx, cl
+		)");
+	TEST("shld rax, rbx, 0");
+	TEST("shld rax, rbx, 1");
+	TEST("shld rax, rbx, 16");
+	TEST("shld rax, rbx, 31");
+	TEST("shld rax, rbx, 32");
+	TEST("shld rax, rbx, 60");
+	TEST("shld rax, rbx, 63");
+	TEST(R"(
+		and cl, 63
+		shld rax, rbx, cl
+		)");
+
+	TEST("shrd ax, bx, 0");
+	TEST("shrd ax, bx, 1");
+	TEST("shrd ax, bx, 3");
+	TEST(R"(
+		and cl, 15
+		shrd ax, bx, cl
+		)");
+	TEST("shrd eax, ebx, 0");
+	TEST("shrd eax, ebx, 1");
+	TEST("shrd eax, ebx, 31");
+	TEST(R"(
+		and cl, 31
+		shrd eax, ebx, cl
+		)");
+	TEST("shrd rax, rbx, 0");
+	TEST("shrd rax, rbx, 1");
+	TEST("shrd rax, rbx, 16");
+	TEST("shrd rax, rbx, 31");
+	TEST("shrd rax, rbx, 32");
+	TEST("shrd rax, rbx, 63");
+	TEST(R"(
+		and cl, 63
+		shrd rax, rbx, cl
+		)");
+
 	size_t passed = 0;
 	for (size_t i = 0; i < tests.size(); i++)
 	{

--- a/NativeLifters-Tests/main.cpp
+++ b/NativeLifters-Tests/main.cpp
@@ -158,10 +158,7 @@ pop rbx)");
 	TEST("shld rax, rbx, 32");
 	TEST("shld rax, rbx, 60");
 	TEST("shld rax, rbx, 63");
-	TEST(R"(
-		and cl, 63
-		shld rax, rbx, cl
-		)");
+	TEST("shld rax, rbx, cl");
 
 	TEST("shrd ax, bx, 0");
 	TEST("shrd ax, bx, 1");
@@ -183,10 +180,7 @@ pop rbx)");
 	TEST("shrd rax, rbx, 31");
 	TEST("shrd rax, rbx, 32");
 	TEST("shrd rax, rbx, 63");
-	TEST(R"(
-		and cl, 63
-		shrd rax, rbx, cl
-		)");
+	TEST("shrd rax, rbx, cl");
 
 	size_t passed = 0;
 	for (size_t i = 0; i < tests.size(); i++)


### PR DESCRIPTION
Fixes #11 .
Original code courtesy of cookie, committing on their behalf and with some fixes.
Tested using the "experiments", test cases:
```
	EXPERIMENT(0x140001000, "shld ax, bx, 0");
	EXPERIMENT(0x140001000, "shld ax, bx, 1");
	EXPERIMENT(0x140001000, "shld ax, bx, 15");
	EXPERIMENT(0x140001000, R"(
		and cl, 15
		shld ax, bx, cl
		)");
	EXPERIMENT(0x140001000, "shld eax, ebx, 0");
	EXPERIMENT(0x140001000, "shld eax, ebx, 1");
	EXPERIMENT(0x140001000, "shld eax, ebx, 31");
	EXPERIMENT(0x140001000, R"(
		and cl, 31
		shld eax, ebx, cl
		)");
	EXPERIMENT(0x140001000, "shld rax, rbx, 0");
	EXPERIMENT(0x140001000, "shld rax, rbx, 1");
	EXPERIMENT(0x140001000, "shld rax, rbx, 16");
	EXPERIMENT(0x140001000, "shld rax, rbx, 31");
	EXPERIMENT(0x140001000, "shld rax, rbx, 32");
	EXPERIMENT(0x140001000, "shld rax, rbx, 60");
	EXPERIMENT(0x140001000, "shld rax, rbx, 63");
	EXPERIMENT(0x140001000, R"(
		and cl, 63
		shld rax, rbx, cl
		)");
```
same goes for `shrd`.
Note that `and cl, 63` in the last test should not be required AFAIK, but removing it sometimes triggers a mismatch on flag bits, probably should be investigated further.