### PR TITLE
Fix fuzzing of branching instructions

### DIFF
--- a/NativeLifters-Tests/fuzzer.hpp
+++ b/NativeLifters-Tests/fuzzer.hpp
@@ -107,8 +107,8 @@ static bool fuzz_step( const lifter::byte_input& input, bool optimize, bool dump
 
 		// If branch is hit, exit VM if jcc/jmp, continue if vmexit. 
 		//
-		if ( ins.base->is_branching_virt() ) return vm_exit_reason::none;
-		if ( ins.base->is_branching_real() ) return vm_exit_reason::unknown_instruction;
+		if ( ins.base->is_branching_virt() || ins.base->is_branching_real())
+			return vm_exit_reason::unknown_instruction;
 
 		// If none matches, redirect to original handler.
 		//

--- a/NativeLifters-Tests/main.cpp
+++ b/NativeLifters-Tests/main.cpp
@@ -182,6 +182,13 @@ pop rbx)");
 	TEST("shrd rax, rbx, 63");
 	TEST("shrd rax, rbx, cl");
 
+	TEST(R"(
+		mov rax, 1
+		je .L
+		mov rax, 2
+	.L: nop
+	)");
+
 	size_t passed = 0;
 	for (size_t i = 0; i < tests.size(); i++)
 	{


### PR DESCRIPTION
Current implementation returns `vm_exit_reason::none` when encountering a branching VTIL instruction, which causes the vm to skip it (see [this loop](https://github.com/vtil-project/VTIL-Core/blob/master/VTIL-Architecture/vm/interface.cpp#L218)). Returning any other reasons causes the instruction to be properly handled, and the new test to pass.

Tbh not sure how to adjust the comment above the `if`.