### PR TITLE
Remove unnecessary creation of add instruction when mem disp is 0

### DIFF
--- a/NativeLifters-Core/amd64/amd64.cpp
+++ b/NativeLifters-Core/amd64/amd64.cpp
@@ -68,9 +68,12 @@ namespace vtil::lifter::amd64
 				->add( current_offs, reg2op( operand.mem.base ) );
 		}
 
-		block
-			// Add the displacement offset.
-			->add( current_offs, operand.mem.disp );
+		if ( operand.mem.disp != 0 )
+		{
+			block
+				// Add the displacement offset.
+				->add(current_offs, operand.mem.disp);
+		}
 
 		// Return resulting temporary.
 		return current_offs;


### PR DESCRIPTION
Instead of
```
| | 0000: [ PSEUDO ]     +0x0     movq     t1           0x0
| | 0001: [ PSEUDO ]     +0x0     addq     t1           $sp
| | 0001: [ PSEUDO ]     +0x0     addq     t1           0x0
| | 0002: [ PSEUDO ]     +0x0     lddb     t0:8         t1           0x0
```
We now get
```
| | 0000: [ PSEUDO ]     +0x0     movq     t1           0x0
| | 0001: [ PSEUDO ]     +0x0     addq     t1           $sp
| | 0002: [ PSEUDO ]     +0x0     lddb     t0:8         t1           0x0
```