### PR TITLE
Fix lifter::recursive_descent memory leak

### DIFF
--- a/NativeLifters-Core/core/recursive_descent.hpp
+++ b/NativeLifters-Core/core/recursive_descent.hpp
@@ -66,6 +66,10 @@ namespace vtil::lifter
 		//
 		basic_block* entry;
 
+		// Routine to which entry belongs
+		//
+		std::unique_ptr<routine> owner_rtn;
+
 		// Instructions corresponding to their basic blocks.
 		//
 		std::unordered_map<uint64_t, basic_block*> leaders;
@@ -75,6 +79,8 @@ namespace vtil::lifter
 		recursive_descent( const input_type* input, uint64_t entry_point, processing_flags flags = {} ) : input( input ), leaders( { } )
 		{
 			entry = basic_block::begin( entry_point );
+			owner_rtn = std::unique_ptr<routine>(entry->owner);
+
 			entry->owner->alloc( 64 ); // reserve one internal for RIP.
 			entry->owner->context.get<processing_flags>() = flags;
 		}


### PR DESCRIPTION
Right now it isn't clear that the routine and the entry basic block created by the lifter are owned by the caller, which causes a memory leak when running NativeLifters-Tests. This commit assigns the ownership of the routine to the `recursive_descent` via a `std::unique_ptr`, which stops the leak.